### PR TITLE
Rename the package namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.gnieh/logback-journal/badge.svg)](http://maven-badges.herokuapp.com/maven-central/org.gnieh/logback-journal)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.dgkncgty/logback-journal/badge.svg)](http://maven-badges.herokuapp.com/maven-central/com.dgkncgty/logback-journal)
 
 logback-journal
 ===============
@@ -11,15 +11,15 @@ Installation
 This appender is published in sonatype maven repository. If you are using maven, simply add the following in your `pom.xml`
 ```xml
 <dependency>
-  <groupId>org.gnieh</groupId>
+  <groupId>com.dgkncgty</groupId>
   <artifactId>logback-journal</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0-SNAPSHOT</version>
 </dependency>
 ```
 
 if you are using sbt, add this to your `build.sbt`
 ```scala
-libraryDependencies += "org.gnieh" % "logback-journal" % "0.3.0"
+libraryDependencies += "com.dgkncgty" % "logback-journal" % "0.4.0-SNAPSHOT"
 ```
 
 You also need the systemd journal library installed on your system to log to it. For newest version of systemd, journal is integrated in the systemd base library. Older version had a separate library named `systemd-journal`.
@@ -32,7 +32,7 @@ Basic configuration to use the systemd journal appender looks like this:
 ```xml
 <configuration>
 
-  <appender name="journal" class="org.gnieh.logback.SystemdJournalAppender" />
+  <appender name="journal" class="com.dgkncgty.logback.SystemdJournalAppender" />
 
   <root level="debug">
     <appender-ref ref="journal" />

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.gnieh</groupId>
+    <groupId>com.dgkncgty</groupId>
     <artifactId>logback-journal</artifactId>
     <version>0.4.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>systemd journal appender for logback</description>
-    <url>https://github.com/gnieh/logback-journal</url>
+    <url>https://github.com/dogukancagatay/logback-journal</url>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -17,26 +17,20 @@
         </license>
     </licenses>
     <name>logback-journal</name>
-    <organization>
-        <name>org.gnieh</name>
-        <url>https://github.com/gnieh/logback-journal</url>
-    </organization>
     <scm>
-        <url>https://github.com/gnieh/logback-journal</url>
-        <connection>scm:git:git://github.com/gnieh/logback-journal.git</connection>
-        <developerConnection>scm:git:git@github.com:gnieh/logback-journal.git</developerConnection>
-        <tag>HEAD</tag>
+        <url>https://github.com/dogukancagatay/logback-journal</url>
+        <connection>scm:git:git://github.com/dogukancagatay/logback-journal.git</connection>
+        <developerConnection>scm:git:ssh@github.com:dogukancagatay/logback-journal.git</developerConnection>
     </scm>
     <developers>
         <developer>
-            <id>satabin</id>
-            <name>Lucas Satabin</name>
-            <email>lucas.satabin@gnieh.org</email>
+            <name>Doğukan Çağatay</name>
+            <email>dcagatay@gmail.com</email>
         </developer>
     </developers>
     <issueManagement>
         <system>github</system>
-        <url>https://github.com/gnieh/logback-journal/issues</url>
+        <url>https://github.com/dogukancagatay/logback-journal/issues</url>
     </issueManagement>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -62,9 +56,9 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Export-Package>org.gnieh.logback</Export-Package>
+                        <Export-Package>com.dgkncgty.logback</Export-Package>
                         <Private-Package></Private-Package>
-                        <Bundle-SymbolicName>org.gnieh.logback.journal</Bundle-SymbolicName>
+                        <Bundle-SymbolicName>com.dgkncgty.logback.journal</Bundle-SymbolicName>
                     </instructions>
                 </configuration>
             </plugin>

--- a/src/main/java/com/dgkncgty/logback/SystemdJournal.java
+++ b/src/main/java/com/dgkncgty/logback/SystemdJournal.java
@@ -13,26 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gnieh.logback;
+package com.dgkncgty.logback;
 
-import com.sun.jna.Library;
-import com.sun.jna.Native;
+import org.slf4j.MDC;
 
 /**
- * Binding to the native journald library.
+ * Some constants that can be used to log some specific data. These constants
+ * are used as keys in {@link MDC}.
  * 
  * @author Lucas Satabin
  * 
  */
-public interface SystemdJournalLibrary extends Library {
+public class SystemdJournal {
 
-    SystemdJournalLibrary INSTANCE = (SystemdJournalLibrary) Native
-            .loadLibrary(System.getProperty("systemd.library", "systemd"), SystemdJournalLibrary.class);
+    private SystemdJournal() {
+        // cannot be instantiated
+    }
 
-    int sd_journal_print(int priority, String format, Object... args);
-
-    int sd_journal_send(String format, Object... args);
-
-    int sd_journal_perror(String message);
+    /** The MESSAGE_ID used for messages logged in this thread */
+    public static String MESSAGE_ID = "MESSAGE_ID";
 
 }

--- a/src/main/java/com/dgkncgty/logback/SystemdJournalAppender.java
+++ b/src/main/java/com/dgkncgty/logback/SystemdJournalAppender.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gnieh.logback;
+package com.dgkncgty.logback;
 
 import java.io.ByteArrayOutputStream;
 import java.io.StringWriter;

--- a/src/main/java/com/dgkncgty/logback/SystemdJournalLibrary.java
+++ b/src/main/java/com/dgkncgty/logback/SystemdJournalLibrary.java
@@ -13,24 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gnieh.logback;
+package com.dgkncgty.logback;
 
-import org.slf4j.MDC;
+import com.sun.jna.Library;
+import com.sun.jna.Native;
 
 /**
- * Some constants that can be used to log some specific data. These constants
- * are used as keys in {@link MDC}.
+ * Binding to the native journald library.
  * 
  * @author Lucas Satabin
  * 
  */
-public class SystemdJournal {
+public interface SystemdJournalLibrary extends Library {
 
-    private SystemdJournal() {
-        // cannot be instantiated
-    }
+    SystemdJournalLibrary INSTANCE = (SystemdJournalLibrary) Native
+            .loadLibrary(System.getProperty("systemd.library", "systemd"), SystemdJournalLibrary.class);
 
-    /** The MESSAGE_ID used for messages logged in this thread */
-    public static String MESSAGE_ID = "MESSAGE_ID";
+    int sd_journal_print(int priority, String format, Object... args);
+
+    int sd_journal_send(String format, Object... args);
+
+    int sd_journal_perror(String message);
 
 }

--- a/src/test/java/com/dgkncgty/logback/SystemdJournalAppenderTest.java
+++ b/src/test/java/com/dgkncgty/logback/SystemdJournalAppenderTest.java
@@ -1,4 +1,4 @@
-package org.gnieh.logback;
+package com.dgkncgty.logback;
 
 import org.junit.After;
 import org.junit.Test;

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <configuration>
 
-  <appender name="journal" class="org.gnieh.logback.SystemdJournalAppender">
+  <appender name="journal" class="com.dgkncgty.logback.SystemdJournalAppender">
     <logLocation>false</logLocation>
     <logException>false</logException>
     <logThreadName>true</logThreadName>
@@ -10,7 +10,7 @@
     <syslogIdentifier>logback-journal-test</syslogIdentifier>
   </appender>
 
-  <appender name="journal-with-source" class="org.gnieh.logback.SystemdJournalAppender">
+  <appender name="journal-with-source" class="com.dgkncgty.logback.SystemdJournalAppender">
     <logSourceLocation>true</logSourceLocation>
     <logThreadName>true</logThreadName>
     <logLoggerName>true</logLoggerName>
@@ -25,7 +25,7 @@
     <appender-ref ref="journal-with-source" />
   </logger>
 
-  <logger name="org.gnieh.logback" level="debug">
+  <logger name="com.dgkncgty.logback" level="debug">
     <appender-ref ref="journal" />
   </logger>
 </configuration>


### PR DESCRIPTION
The upstream project was [archived](https://github.com/gnieh/logback-journal/commit/da76d1b4c50a85b5f67530f92d2f24501eff3614), so renaming the namespace to push the package to the Maven repository.