### PR TITLE
lib: refactor deprecated jna library call

### DIFF
--- a/src/main/java/com/dgkncgty/logback/SystemdJournalLibrary.java
+++ b/src/main/java/com/dgkncgty/logback/SystemdJournalLibrary.java
@@ -26,7 +26,7 @@ import com.sun.jna.Native;
 public interface SystemdJournalLibrary extends Library {
 
     SystemdJournalLibrary INSTANCE = Native
-            .loadLibrary(System.getProperty("systemd.library", "systemd"), SystemdJournalLibrary.class);
+            .load(System.getProperty("systemd.library", "systemd"), SystemdJournalLibrary.class);
 
     int sd_journal_print(int priority, String format, Object... args);
 


### PR DESCRIPTION
Replaced deprecated `loadLibrary` call.

- **lib: refactor deprecated jna library calls**
