### PR TITLE
test: replace unit test dependency with junit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,9 +139,9 @@
             <version>1.3.14</version>
         </dependency>
         <dependency>
-            <groupId>com.github.sbt</groupId>
-            <artifactId>junit-interface</artifactId>
-            <version>0.13.3</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The previous dependency was a residual SBT interface to the junit, from
before which didn't add any value, so it is replaced it with junit itself.
