### PR TITLE
Fix gh action package publishing to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Build and Publish
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 env:
   JAVA_VERSION: "8"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CI trigger change; main risk is altering when the publish job runs (potentially delaying or skipping publishes if expectations differ).
> 
> **Overview**
> Updates the `release.yml` GitHub Actions workflow trigger to run on **release `published`** events instead of `created`, ensuring the Maven Central publish job only runs when a release is actually published.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8281d632413033a3b50e0fd56d8a04361a51f45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->