### PR TITLE
Change waitUntil configuration from 'published' to 'validated'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
                     <publishingServerId>central</publishingServerId>
                     <skipPublishing>${package.skipPublishing}</skipPublishing>
                     <autoPublish>${package.autoPublish}</autoPublish>
-                    <waitUntil>published</waitUntil>
+                    <waitUntil>validated</waitUntil>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Publishing stage on the maven central side takes too much time, this PR makes sure that it doesn't wait until the package was published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/publishing configuration-only change; risk is limited to potentially reporting success before artifacts are fully visible on Maven Central.
> 
> **Overview**
> Updates the `central-publishing-maven-plugin` configuration in `pom.xml` to change `waitUntil` from `published` to `validated`, so release jobs stop waiting for Maven Central’s full publish step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e5925f8895f6f1f595fa895ce0da03f99ae1dcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->