### PR TITLE
Update version to 1.0.0-SNAPSHOT for Java 11+ only release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dgkncgty</groupId>
     <artifactId>logback-journal</artifactId>
-    <version>0.5.1</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>logback-journal</name>


### PR DESCRIPTION
Prepare to release 1.0.0 with Java 11 support, dropping EOL Java 8,
requiring Java 11 as minimum version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the Maven project version; runtime behavior is unaffected, with risk limited to build/release packaging and dependency consumers.
> 
> **Overview**
> Updates the project’s Maven coordinates by bumping `pom.xml` version from `0.5.1` to `1.0.0-SNAPSHOT` to start the 1.0.0 development/release track.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 970cf600f6be6282b082d2becc3e342dd4fea8cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->