### PR TITLE
Drop Java 8 support, set minimum Java version to 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  JAVA_VERSION: "8"
+  JAVA_VERSION: "11"
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     # Make sure it builds for LTS versions of Java
     strategy:
       matrix:
-        java_version: [8, 11, 17, 21]
+        java_version: [11, 17, 21]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  JAVA_VERSION: "8"
+  JAVA_VERSION: "11"
   MAVEN_PROFILE: "gh-action"
 
 jobs:

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
     </issueManagement>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Support for Java 8 has diminished, and newer versions of several
dependencies no longer support it. The minimum supported Java
version is now Java 11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI-only change that raises the minimum supported Java version; main risk is breaking consumers or environments still on Java 8.
> 
> **Overview**
> **Drops Java 8 support and sets Java 11 as the minimum runtime/compile target.** CI workflows (`main.yml`, `release.yml`) now use JDK 11 by default, and PR builds remove Java 8 from the test matrix.
> 
> `pom.xml` switches from `maven.compiler.source/target=1.8` to `maven.compiler.release=11`, ensuring compilation targets Java 11 bytecode/API level.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6583c764da7e37edb6ef4155f9b4f517bfdab5ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->