### PR TITLE
Add null check for stack trace array to prevent NullPointerException

### DIFF
--- a/src/main/java/com/dgkncgty/logback/SystemdJournalAppender.java
+++ b/src/main/java/com/dgkncgty/logback/SystemdJournalAppender.java
@@ -77,7 +77,7 @@ public class SystemdJournalAppender extends AppenderBase<ILoggingEvent> {
 
             if (hasException(event)) {
                 StackTraceElementProxy[] stack = event.getThrowableProxy().getStackTraceElementProxyArray();
-                if (stack.length > 0) {
+                if (stack != null && stack.length > 0) {
 
                     // the location information if any is available and it is
                     // enabled


### PR DESCRIPTION
The getStackTraceElementProxyArray() method can return null, but the
code was accessing stack.length without checking for null first. This
could cause a NullPointerException when logging exceptions with empty
stack traces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in logging code that only affects how exceptions with null/empty stack traces are handled.
> 
> **Overview**
> Prevents a potential `NullPointerException` in `SystemdJournalAppender` by adding a null check around `getStackTraceElementProxyArray()` before accessing `stack.length` and using the first frame for location/exception logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa5457e59489d4286d5ec78011a01204a1b5b0eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->