### PR TITLE
Add Java 25 to PR build matrix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     # Make sure it builds for LTS versions of Java
     strategy:
       matrix:
-        java_version: [11, 17, 21]
+        java_version: [11, 17, 21, 25]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Add Java 25 to the list of JDK versions tested in pull request builds
to ensure compatibility with the latest LTS release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that increases test coverage; no production code or runtime behavior is modified.
> 
> **Overview**
> Expands the PR GitHub Actions build matrix to also run the Maven build on **Java 25** (in addition to 11/17/21), increasing CI coverage for the latest LTS JDK.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b524e07d0fa3075ac35e13c1b05e0acbd7a4570. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->